### PR TITLE
Added .env() to logger to listen to RUST_LOG env varibale

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ static CONFLICT_MATCHER: LazyLock<globset::GlobMatcher> = LazyLock::new(|| {
 fn main() -> anyhow::Result<()> {
     // Init logger
     simple_logger::SimpleLogger::new()
+        .env()
         .init()
         .context("Failed to init logger")?;
 


### PR DESCRIPTION
To avoid log spamming, listen to RUST_LOG environment variable. If not set SimpleLogger will use trace